### PR TITLE
Fix percent decoding in query string parsing

### DIFF
--- a/src/mnemosyne.gleam
+++ b/src/mnemosyne.gleam
@@ -98,7 +98,15 @@ fn uri_decode(x: String) -> String {
   decode_percent(plus)
 }
 
+@external(erlang, "uri_string", "percent_decode")
+fn erlang_percent_decode(bs: BitString) -> BitString
+
 fn decode_percent(s: String) -> String {
-  // Simplified URL decode - just replace + with spaces for now
-  string.replace(s, "+", " ")
+  // Decode percent-encoded sequences using Erlang's uri_string module
+  let bytes = string.to_utf8(s)
+  let decoded = erlang_percent_decode(bytes)
+  case string.from_utf8(decoded) {
+    Ok(text) -> text
+    Error(_) -> s
+  }
 }

--- a/test/mnemosyne_test.gleam
+++ b/test/mnemosyne_test.gleam
@@ -1,4 +1,5 @@
 import gleeunit
+import mnemosyne
 
 pub fn main() -> Nil {
   gleeunit.main()
@@ -10,4 +11,10 @@ pub fn hello_world_test() {
   let greeting = "Hello, " <> name <> "!"
 
   assert greeting == "Hello, Joe!"
+}
+
+pub fn parse_qs_decodes_percent_test() {
+  let qs = "title=Hello%20World+Again"
+  let expected = [#("title", "Hello World Again")]
+  assert mnemosyne.parse_qs(qs) == expected
 }


### PR DESCRIPTION
## Summary
- handle percent-encoded sequences in query string values using `uri_string:percent_decode`
- add regression test for percent-decoded query parameters

## Testing
- `gleam test` *(fails: HTTP error fetching https://repo.hex.pm/tarballs/esqlite-0.8.9.tar)*

------
https://chatgpt.com/codex/tasks/task_b_6897945ba84c8320870c2bbdcfbbe20f