### PR TITLE
feat: support bookmarklet confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ Further documentation can be found at <https://hexdocs.pm/mnemosyne>.
 gleam run   # Run the project
 gleam test  # Run the tests
 ```
+
+## Bookmarklet
+
+Links can be added directly from the browser using the `/add/confirm` route:
+
+```
+/add/confirm?url=<URL>&title=<TITLE>
+```
+
+The link is stored and the response redirects back to the provided URL
+with a plain text confirmation, making it suitable for bookmarklets.

--- a/src/mnemosyne.gleam
+++ b/src/mnemosyne.gleam
@@ -26,6 +26,19 @@ pub fn main() {
         render_html(view.page(links))
       }
 
+      ["", "add", "confirm"] -> {
+        let params = r.query |> option.unwrap("") |> parse_qs
+        let url = dict_get(params, "url") |> option.unwrap("")
+        let title = dict_get(params, "title") |> option.unwrap(url)
+        case url {
+          "" -> redirect("/")
+          _ -> {
+            links_store.add_link(url, title)
+            redirect_with_message(url, "Added " <> title)
+          }
+        }
+      }
+
       ["", "add"] -> {
         let params = r.query |> option.unwrap("") |> parse_qs
         let url = dict_get(params, "url") |> option.unwrap("")
@@ -57,6 +70,16 @@ fn redirect(location: String) -> res.Response(mist.ResponseData) {
   res.new(302)
   |> res.set_header("Location", location)
   |> res.set_body(mist.Bytes(bytes_tree.from_string("")))
+}
+
+fn redirect_with_message(
+  location: String,
+  message: String,
+) -> res.Response(mist.ResponseData) {
+  res.new(302)
+  |> res.set_header("Location", location)
+  |> res.set_header("content-type", "text/plain; charset=utf-8")
+  |> res.set_body(mist.Bytes(bytes_tree.from_string(message)))
 }
 
 fn render_html(el) -> res.Response(mist.ResponseData) {


### PR DESCRIPTION
## Summary
- add `/add/confirm` route for bookmarklet use that stores link and redirects back to the page with confirmation text
- introduce `redirect_with_message` helper
- document bookmarklet route in README

## Testing
- `gleam test` (fails: HTTP error for https://repo.hex.pm/tarballs/esqlite-0.8.9.tar)


------
https://chatgpt.com/codex/tasks/task_b_689a41f6db588320881b243f6ae419d3