### PR TITLE
Decode percent-encoded query parameters

### DIFF
--- a/src/mnemosyne.gleam
+++ b/src/mnemosyne.gleam
@@ -1,3 +1,4 @@
+import gleam/bit_array
 import gleam/bytes_tree
 import gleam/erlang/process
 import gleam/http/request as req
@@ -5,7 +6,6 @@ import gleam/http/response as res
 import gleam/list
 import gleam/option
 import gleam/string
-import gleam/bit_array
 import lustre/element
 import mist
 
@@ -100,11 +100,12 @@ fn uri_decode(x: String) -> String {
 }
 
 @external(erlang, "uri_string", "percent_decode")
-fn erlang_percent_decode(bit_array.BitArray) -> bit_array.BitArray
+fn erlang_percent_decode(bit_array: BitArray) -> BitArray
 
 fn decode_percent(s: String) -> String {
-  s
-  |> string.to_utf8
+  let assert Ok(result) = s
+  |> bit_array.from_string
   |> erlang_percent_decode
-  |> string.from_utf8
+  |> bit_array.to_string
+  result
 }

--- a/src/mnemosyne.gleam
+++ b/src/mnemosyne.gleam
@@ -5,6 +5,7 @@ import gleam/http/response as res
 import gleam/list
 import gleam/option
 import gleam/string
+import gleam/bit_array
 import lustre/element
 import mist
 
@@ -98,7 +99,12 @@ fn uri_decode(x: String) -> String {
   decode_percent(plus)
 }
 
+@external(erlang, "uri_string", "percent_decode")
+fn erlang_percent_decode(bit_array.BitArray) -> bit_array.BitArray
+
 fn decode_percent(s: String) -> String {
-  // Simplified URL decode - just replace + with spaces for now
-  string.replace(s, "+", " ")
+  s
+  |> string.to_utf8
+  |> erlang_percent_decode
+  |> string.from_utf8
 }


### PR DESCRIPTION
## Summary
- decode percent-encoded query parameters using Erlang's `uri_string:percent_decode`

## Testing
- `gleam test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689ae4b9f8348320871491e9311731a5