### PR TITLE
Add bookmarklet link for quick saving

### DIFF
--- a/src/view.gleam
+++ b/src/view.gleam
@@ -71,6 +71,17 @@ pub fn page(links: List(Link)) -> element.Element(a) {
           ],
           items,
         ),
+        html.p([], [
+          html.text("Drag this link to your bookmarks bar: "),
+          html.a(
+            [
+              attr.href(
+                "javascript:(function(){function E(s){return encodeURIComponent(s)}var c=document.querySelector('link[rel=\\\"canonical\\\"]');var u=(c&&c.href)||location.href;var t=document.title;window.open('https://mnemosyne.godkjemi.net/add?url='+E(u)+'&title='+E(t),'_blank')})();",
+              ),
+            ],
+            [html.text("Add to Mnemosyne")],
+          ),
+        ]),
       ],
     ),
   ])


### PR DESCRIPTION
## Summary
- add bookmarklet block so users can easily save pages to Mnemosyne

## Testing
- `gleam test` *(fails: HTTP error downloading https://repo.hex.pm/tarballs/esqlite-0.8.9.tar)*

------
https://chatgpt.com/codex/tasks/task_b_689b7702dd4c832090e6e80b8cbacb59